### PR TITLE
Issue #22 - Enforce min/max consistency for FacetedScalars

### DIFF
--- a/src/language-server/oml-validator.ts
+++ b/src/language-server/oml-validator.ts
@@ -111,9 +111,9 @@ export class OmlValidator {
 
         // Check consistent minInclusive and maxInclusive
         if (facetScalar.minInclusive != undefined && facetScalar.maxInclusive != undefined) {
-            if ((facetScalar.minInclusive.$type == "IntegerLiteral" && facetScalar.maxInclusive.$type == "IntegerLiteral") ||
-                    (facetScalar.minInclusive.$type == "DecimalLiteral" && facetScalar.maxInclusive.$type == "DecimalLiteral") ||
-                    (facetScalar.minInclusive.$type == "DoubleLiteral" && facetScalar.maxInclusive.$type == "DoubleLiteral")) {
+            if ((isIntegerLiteral(facetScalar.minInclusive) && isIntegerLiteral(facetScalar.maxInclusive)) ||
+                    (isDecimalLiteral(facetScalar.minInclusive) && isDecimalLiteral(facetScalar.maxInclusive)) ||
+                    (isDoubleLiteral(facetScalar.minInclusive) && isDoubleLiteral(facetScalar.maxInclusive))) {
                 if (facetScalar.maxInclusive.value < facetScalar.minInclusive.value) {
                     accept('error', `${facetScalar.name} has a minInclusive value that is greater than its maxInclusive value`, {node: facetScalar, property: 'minInclusive'});
                     accept('error', `${facetScalar.name} has a maxInclusive value that is less than its minInclusive value`, {node: facetScalar, property: 'maxInclusive'});    


### PR DESCRIPTION
Added three validations for faceted scalars that ensures minLength, maxLength, minInclusive, maxInclusive, minExclusive, and maxExclusive are all set to logically consistent values.
Specific checks:
- minLength<=maxLength
- minInclusive<=maxInclusive
- minExclusive<=maxExclusive
- minLength, maxLength, length, pattern, and language cannot be defined if and inclusive/exclusive properties are defined
- inclusive/exclusive properties cannot be booleans
- inclusive/exclusive properties that are defined must have all the same types

Fixes #22