### PR TITLE
Fix warning/error placement bug 

### DIFF
--- a/src/language-server/oml-validator.ts
+++ b/src/language-server/oml-validator.ts
@@ -325,7 +325,9 @@ export class OmlValidator {
             for (let i = 0; i < enumScalar.ownedSpecializations.length; i++) {
                 accept('error', `${enumScalar.name} specializes a supertype but also has enumerated literals`, {node: enumScalar, property: 'ownedSpecializations', index: i});
             }
-            accept('error', `${enumScalar.name} has enumerated literals but also specializes a supertype`, {node: enumScalar, property: 'literals'});
+            for (let i = 0; i < enumScalar.literals.length; i++) {
+                accept('error', `${enumScalar.name} has enumerated literals but also specializes a supertype`, {node: enumScalar, property: 'literals', index: i});
+            }
         }
     }
 


### PR DESCRIPTION
Warnings and errors were not showing up at the correct place in some arrays (e.g. specialized terms) due to a missing `index` parameter in the info of some validator rules. This PR adds the index where appropriate to fix the cosmetic issue.