### PR TITLE
Add task issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/story.md
+++ b/.github/ISSUE_TEMPLATE/story.md
@@ -11,7 +11,7 @@ assignees: ''
 As a **[Role]**, I would like **[Requirement]** so that **[Reason]**.
 
 ## Detailed Description
-Provide additional details and context.
+Provide additional details and context. Include tasks (if relevant).
 
 ## Acceptance Criteria
 - [ ] Given **[Condition]**, then **[Expected Result]**

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,11 @@
+---
+name: Task
+about: Describe an implementation step for a story
+title: ''
+labels: 'task'
+assignees: ''
+
+---
+
+## Detailed Description
+Provide additional details and context.


### PR DESCRIPTION
Adds a new issue template for tasks, so we can back-date work completed during Sprints 1 & 2 (which consisted mostly of tasks in service of stories).